### PR TITLE
Made the version string in the Podspec Ruby friendly

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage           = 'https://github.com/square/SocketRocket'
   s.authors            = 'Square'
   s.license            = 'Apache License, Version 2.0'
-  s.source             = { :git => 'https://github.com/square/SocketRocket.git', :commit => '82c9f8938f8b9b7aa578866cb7ce56bc11e52ced' }
+  s.source             = { :git => 'https://github.com/square/SocketRocket.git', :tag => 'v0.3.1.beta2' }
   s.source_files       = 'SocketRocket/*.{h,m,c}'
   s.requires_arc       = true
   s.ios.frameworks     = %w{CFNetwork Security}

--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name               = "SocketRocket"
-  s.version            = '0.3.1-beta2'
+  s.version            = '0.3.1.beta2'
   s.summary            = 'A conforming WebSocket (RFC 6455) client library.'
   s.homepage           = 'https://github.com/square/SocketRocket'
   s.authors            = 'Square'


### PR DESCRIPTION
Here's a minor change that keeps the pod linter from puking when you try to specify pre-release versions of SocketRocket in your Podfile. Use periods instead of hyphens!