### PR TITLE
change location of headers for iOS static lib target

### DIFF
--- a/SRWebSocketTests/SRTAutobahnTests.m
+++ b/SRWebSocketTests/SRTAutobahnTests.m
@@ -16,7 +16,7 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 #import <SenTestingKit/SenTestRun.h>
-#import "SRWebSocket.h"
+#import <SocketRocket/SRWebSocket.h>
 #import "SRTWebSocketOperation.h"
 #import "SenTestCase+SRTAdditions.h"
 

--- a/SRWebSocketTests/SRTWebSocketOperation.h
+++ b/SRWebSocketTests/SRTWebSocketOperation.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SRWebSocket.h"
+#import <SocketRocket/SRWebSocket.h>
 
 @interface SRTWebSocketOperation : NSOperation <SRWebSocketDelegate>
 

--- a/SRWebSocketTests/SRTWebSocketOperation.m
+++ b/SRWebSocketTests/SRTWebSocketOperation.m
@@ -7,7 +7,6 @@
 //
 
 #import "SRTWebSocketOperation.h"
-#import "SRWebSocket.h"
 
 @interface SRTWebSocketOperation ()
 

--- a/SocketRocket.xcodeproj/project.pbxproj
+++ b/SocketRocket.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		F6016C7C146124B20037BB3D /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = F6016C7B146124B20037BB3D /* base64.c */; };
-		F6016C7F146124ED0037BB3D /* base64.h in Headers */ = {isa = PBXBuildFile; fileRef = F6016C7E146124ED0037BB3D /* base64.h */; };
 		F6016C8814620EC70037BB3D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6A12CD3145122FC00C1D980 /* Security.framework */; };
 		F6016C8914620ECC0037BB3D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6A12CD3145122FC00C1D980 /* Security.framework */; };
 		F6016C8A1462143C0037BB3D /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6A12CD51451231B00C1D980 /* CFNetwork.framework */; };
@@ -35,7 +34,7 @@
 		F668C89A153E923C0044DBAC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6396BA1153E6D4800345B5E /* Foundation.framework */; };
 		F668C89B153E923C0044DBAC /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6396B9F153E6D3700345B5E /* Security.framework */; };
 		F668C8AA153E92F90044DBAC /* SRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = F6A12CCF145119B700C1D980 /* SRWebSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F6A12CD1145119B700C1D980 /* SRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = F6A12CCF145119B700C1D980 /* SRWebSocket.h */; };
+		F6A12CD1145119B700C1D980 /* SRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = F6A12CCF145119B700C1D980 /* SRWebSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F6A12CD2145119B700C1D980 /* SRWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = F6A12CD0145119B700C1D980 /* SRWebSocket.m */; };
 		F6AE451D145906A70022AF3C /* libSocketRocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6B2082D1450F597009315AF /* libSocketRocket.a */; };
 		F6AE4520145906B20022AF3C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6B208301450F597009315AF /* Foundation.framework */; };
@@ -316,7 +315,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F6A12CD1145119B700C1D980 /* SRWebSocket.h in Headers */,
-				F6016C7F146124ED0037BB3D /* base64.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -705,6 +703,7 @@
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -723,6 +722,7 @@
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/TestChat/TCViewController.m
+++ b/TestChat/TCViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "TCViewController.h"
-#import "SRWebSocket.h"
+#import <SocketRocket/SRWebSocket.h>
 #import "TCChatCell.h"
 
 @interface TCMessage : NSObject


### PR DESCRIPTION
loosen the requirement that an application/super-project must reference the subproject headers explicitly through the source tree; also avoids copying the headers at application archive time; see jamie montgomerie’s explanation here: http://www.blog.montgomerie.net/easy-xcode-static-library-subprojects-and-submodules

i should also mention, the PR should not require existing iOS SocketRocket clients to change how headers are referenced (as one could always use headers from the project source tree itself), but makes the headers available in a framework style #import <SocketRocket/SRWebSocket.h.h> much like one would find on Mac OS X after a header search path tweak.