### PR TITLE
Allow this framework to be bundled more flexibly on OS X

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ more rhudimentary and less robust.
 2. Add ``SocketRocket.framework`` to the link libraries
 3. If you don't have a "copy files" step for ``Framework``, create one
 4. Add ``SocketRocket.framework`` to the "copy files" step.
+5. Add ``@loader_path/../Frameworks`` to the "Runpath Search Paths" setting of your app target
 
 API
 ---

--- a/SocketRocket.xcodeproj/project.pbxproj
+++ b/SocketRocket.xcodeproj/project.pbxproj
@@ -602,7 +602,7 @@
 				GCC_PREFIX_HEADER = "SocketRocket/SocketRocket-Prefix.pch";
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "SocketRocketOSX/SocketRocketOSX-Info.plist";
-				LD_DYLIB_INSTALL_NAME = "@executable_path/../Frameworks/$(EXECUTABLE_PATH)";
+				INSTALL_PATH = "@rpath";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SocketRocket;
@@ -629,7 +629,7 @@
 				GCC_PREFIX_HEADER = "SocketRocket/SocketRocket-Prefix.pch";
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "SocketRocketOSX/SocketRocketOSX-Info.plist";
-				LD_DYLIB_INSTALL_NAME = "@executable_path/../Frameworks/$(EXECUTABLE_PATH)";
+				INSTALL_PATH = "@rpath";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SocketRocket;
 				SDKROOT = macosx;


### PR DESCRIPTION
(e.g. as a subframework within another bundle)

See these for more discussion of why this is better:
http://overooped.com/post/87887322/use-rpath-instead-of-loader-path-or-executable-path
http://www.dribin.org/dave/blog/archives/2009/11/15/rpath/

In my case, I needed SocketRocket to be a ± hidden dependency within a site-specific framework and the app could not be deployed with the previous installation path. (simply using `@loader_path` does work because within an app it would be at `@loader_path/../Frameworks` but within a parent framework it needs `@loader_path/Frameworks`.)