### PR TITLE
Fixed bad_access that could occur when releasing _workQueue on dealloc

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -381,8 +381,10 @@ static __strong NSData *CRLFCRLF;
     [_inputStream close];
     [_outputStream close];
     
-    sr_dispatch_release(_workQueue);
-    _workQueue = NULL;
+    if (_workQueue) {
+        sr_dispatch_release(_workQueue);
+        _workQueue = NULL;
+    }
     
     if (_receivedHTTPHeaders) {
         CFRelease(_receivedHTTPHeaders);


### PR DESCRIPTION
Hi. 

I encountered a BAD_ACCESS on dealloc in SRWebSocket. It happened because you were not testing if _workQueue is nil before releasing it. This should fix it.

Cheers,
Jan