### PR TITLE
WebSocket never releasing, nor really closing.

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1172,9 +1172,13 @@ static const char CRLFCRLFBytes[] = {'\r', '\n', '\r', '\n'};
     BOOL didWork = NO;
     
     if (self.readyState >= SR_CLOSING) {
+        dispatch_async(_workQueue, ^{
+            _closeCode = SRStatusCodeNormal;
+            [self _disconnect];
+        });
         return didWork;
     }
-    
+
     if (!_consumers.count) {
         return didWork;
     }


### PR DESCRIPTION
Fix: memory leak and lack of actually closing the WebSocket.
Result: WebSocket is no longer retained indefinitely, delegate is notified of the closure, and the connection to the WebSocket server is severed.
Explanation: On sending a -[SRWebSocket close] message, the WebSocket server responds by echoing the close message back to us.
Nothing is done with this response. This can be verified by playing with the Chat test app.
Added setting _closeCode = SRStatusCodeNormal and sending -[SRWebSocket _disconnect] in -[SRWebSocket _innerPumpScanner]. This results in the various streams being closed, the delegate notified of the closure, and the severing of the actual connections to the WebSocket server.