### PR TITLE
Add receivedHTTPHeaders array to public properties

### DIFF
--- a/SocketRocket.xcodeproj/project.xcworkspace/xcshareddata/SocketRocket.xccheckout
+++ b/SocketRocket.xcodeproj/project.xcworkspace/xcshareddata/SocketRocket.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>B648E219-646D-48EA-8033-F2823B6879E3</string>
+	<key>IDESourceControlProjectName</key>
+	<string>SocketRocket</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>82B4653C-9497-408E-B1DC-123266231DC4</key>
+		<string>ssh://github.com/aaronvegh/SocketRocket.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>SocketRocket.xcodeproj/project.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>82B4653C-9497-408E-B1DC-123266231DC4</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>ssh://github.com/aaronvegh/SocketRocket.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>82B4653C-9497-408E-B1DC-123266231DC4</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>82B4653C-9497-408E-B1DC-123266231DC4</string>
+			<key>IDESourceControlWCCName</key>
+			<string>SocketRocket</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -41,6 +41,8 @@ extern NSString *const SRWebSocketErrorDomain;
 @property (nonatomic, readonly) SRReadyState readyState;
 @property (nonatomic, readonly, retain) NSURL *url;
 
+@property (nonatomic, readonly) CFHTTPMessageRef receivedHTTPHeaders;
+
 // This returns the negotiated protocol.
 // It will be nil until after the handshake completes.
 @property (nonatomic, readonly, copy) NSString *protocol;

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -269,7 +269,7 @@ typedef void (^data_callback)(SRWebSocket *webSocket,  NSData *data);
     BOOL _secure;
     NSURLRequest *_urlRequest;
 
-    CFHTTPMessageRef _receivedHTTPHeaders;
+    
     
     BOOL _sentClose;
     BOOL _didFail;


### PR DESCRIPTION
This is my first-ever pull request; apologies if I'm not doing this right. 

For my application I need to get the actual headers served up by the web service in the event of a failure. However the receivedHTTPHeaders property is private in the current release. My change puts that property in the public so my app can access them. I'm not sure if there's a Very Good Reason™ why the headers aren't currently available, but this change was useful to me.

Thanks for reading! This has been such a terrific library of code to use, so thanks for all your great work.