### PR TITLE
Adds sendPong for sending unsolicited pong messages.

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -71,6 +71,9 @@ extern NSString *const SRWebSocketErrorDomain;
 // Send a UTF8 String or Data.
 - (void)send:(id)data;
 
+// Send unsolicited pong message
+- (void)sendPong;
+
 @end
 
 #pragma mark - SRWebSocketDelegate

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -720,6 +720,13 @@ static __strong NSData *CRLFCRLF;
     });
 }
 
+- (void)sendPong;
+{
+    dispatch_async(_workQueue, ^{
+        [self _sendFrameWithOpcode:SROpCodePong data:[NSData new]];
+    });
+}
+
 - (void)handlePing:(NSData *)pingData;
 {
     // Need to pingpong this off _callbackQueue first to make sure messages happen in order


### PR DESCRIPTION
According to the websocket specification a pong message can be sent unsolicited. This was not possible with the current API.

Pull requests adds new method sendPong for triggering an unsolicited pong message. Used and tested in an iOS app to keep the connection alive (heartbeat).