### PR TITLE
Keeping original NSURLRequest object HTTPMethod and HTTPBody

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -498,7 +498,12 @@ static __strong NSData *CRLFCRLF;
 - (void)didConnect
 {
     SRFastLog(@"Connected");
-    CFHTTPMessageRef request = CFHTTPMessageCreateRequest(NULL, CFSTR("GET"), (__bridge CFURLRef)_url, kCFHTTPVersion1_1);
+
+    NSString *httpMethod = _urlRequest.HTTPMethod;
+    CFHTTPMessageRef request = CFHTTPMessageCreateRequest(NULL, (__bridge CFStringRef)httpMethod, (__bridge CFURLRef)_url, kCFHTTPVersion1_1);
+
+    NSData *bodyData = _urlRequest.HTTPBody;
+    CFHTTPMessageSetBody( request, (__bridge CFDataRef)bodyData );
     
     // Set host first so it defaults
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (__bridge CFStringRef)(_url.port ? [NSString stringWithFormat:@"%@:%@", _url.host, _url.port] : _url.host));


### PR DESCRIPTION
Not stripping the original `NSURLRequest` object `HTTPBody` and keeping its `HTTPMethod` gives us the possibility of doing some checks on the server before establishing the websocket. For example, you could have something like this using `ruby`, `sinatra` and `sinatra-websockets`:

```ruby
post '/web-socket-url' do
  if !request.websocket?
    return status 404
  end

  # Without HTTP method post and body data we can't do this in a proper way... Only if we sent
  # this parameter in the query string, what's not good for sensible data
  user_access_token = params[:user_token]

  if !( is_valid_token? user_access_token )
    return status 404
  end

  # Only now we establish the websocket
  request.websocket do |ws|

    ws.onopen do
      # ...
    end

    ws.onmessage do |message|
      # ...
    end

    ws.onclose do
      # ...
    end
  end
end
```