### PR TITLE
Evaluate certificate chain trust using SecTrustEvaluate

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1389,7 +1389,7 @@ static BOOL evaluateServerTrust(SecTrustRef serverTrust) {
 
     OSStatus status = SecTrustEvaluate(serverTrust, &result);
     
-    isValid = ((result == kSecTrustResultUnspecified || result == kSecTrustResultProceed) && status == 0);
+    isValid = ((result == kSecTrustResultUnspecified) && status == 0);
 
     return isValid;
 }


### PR DESCRIPTION
The current pinning approach is quite restrictive. This PR fixes the issue of pinning with signing certificates instead of direct public key pinning.
This should work for current users without changing their code.
Uses the built-in chain evaluation function.