### PR TITLE
Read network service type from NSURLRequest instances

### DIFF
--- a/SRWebSocketTests/SRWebSocketTests-Prefix.pch
+++ b/SRWebSocketTests/SRWebSocketTests-Prefix.pch
@@ -19,3 +19,7 @@
     #import <SenTestingKit/SenTestingKit.h>
     #import "SenTestCase+SRTAdditions.h"
 #endif
+
+#if TARGET_OS_IPHONE
+    #import <UIKit/UIKit.h>
+#endif

--- a/SRWebSocketTests/SRWebSocketTests-Prefix.pch
+++ b/SRWebSocketTests/SRWebSocketTests-Prefix.pch
@@ -20,6 +20,12 @@
     #import "SenTestCase+SRTAdditions.h"
 #endif
 
-#if TARGET_OS_IPHONE
-    #import <UIKit/UIKit.h>
+#if defined(TARGET_OS_IPHONE) && defined(TARGET_OS_SIMULATOR)
+    #if (TARGET_OS_IPHONE || TARGET_OS_SIMULATOR)
+        #import <UIKit/UIKit.h>
+    #endif
+#elif defined(TARGET_OS_IPHONE) && defined(TARGET_IPHONE_SIMULATOR)
+    #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+        #import <UIKit/UIKit.h>
+    #endif
 #endif

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -27,6 +27,7 @@
 
 #if TARGET_OS_IPHONE
 #import <Endian.h>
+#import <UIKit/UIKit.h>
 #else
 #import <CoreServices/CoreServices.h>
 #endif
@@ -592,12 +593,14 @@ static __strong NSData *CRLFCRLF;
         case NSURLNetworkServiceTypeDefault:
             return;
         case NSURLNetworkServiceTypeVoIP: {
+#if TARGET_OS_IPHONE
             // voice over IP control - this service type is deprecated in favor of using PushKit for VoIP control
-            if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_3) {
-                return;
+            if ([[UIDevice currentDevice].systemVersion compare:@"9.0" options:NSNumericSearch] == NSOrderedAscending) {
+                networkServiceType = NSStreamNetworkServiceTypeVoIP;
+                break;
             }
-            networkServiceType = NSStreamNetworkServiceTypeVoIP;
-            break;
+#endif
+            return;
         }
         case NSURLNetworkServiceTypeVideo:
             networkServiceType = NSStreamNetworkServiceTypeVideo;

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -586,6 +586,26 @@ static __strong NSData *CRLFCRLF;
     
     _inputStream.delegate = self;
     _outputStream.delegate = self;
+    
+    NSString *networkServiceType;
+    switch (_urlRequest.networkServiceType) {
+        case NSURLNetworkServiceTypeVoIP:
+            networkServiceType = NSStreamNetworkServiceTypeVoIP;
+            break;
+        case NSURLNetworkServiceTypeVideo:
+            networkServiceType = NSStreamNetworkServiceTypeVideo;
+            break;
+        case NSURLNetworkServiceTypeBackground:
+            networkServiceType = NSStreamNetworkServiceTypeBackground;
+            break;
+        case NSURLNetworkServiceTypeVoice:
+            networkServiceType = NSStreamNetworkServiceTypeVoice;
+            break;
+        default:
+            break;
+    }
+    [_inputStream setProperty:networkServiceType forKey:NSStreamNetworkServiceType];
+    [_outputStream setProperty:networkServiceType forKey:NSStreamNetworkServiceType];
 }
 
 - (void)_connect;

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -589,9 +589,16 @@ static __strong NSData *CRLFCRLF;
     
     NSString *networkServiceType;
     switch (_urlRequest.networkServiceType) {
-        case NSURLNetworkServiceTypeVoIP:
+        case NSURLNetworkServiceTypeDefault:
+            return;
+        case NSURLNetworkServiceTypeVoIP: {
+            // voice over IP control - this service type is deprecated in favor of using PushKit for VoIP control
+            if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_3) {
+                return;
+            }
             networkServiceType = NSStreamNetworkServiceTypeVoIP;
             break;
+        }
         case NSURLNetworkServiceTypeVideo:
             networkServiceType = NSStreamNetworkServiceTypeVideo;
             break;
@@ -600,8 +607,6 @@ static __strong NSData *CRLFCRLF;
             break;
         case NSURLNetworkServiceTypeVoice:
             networkServiceType = NSStreamNetworkServiceTypeVoice;
-            break;
-        default:
             break;
     }
     [_inputStream setProperty:networkServiceType forKey:NSStreamNetworkServiceType];


### PR DESCRIPTION
In order to use SocketRocket with background mode, we have to set the NSURLNetworkServiceType on the NSURLRequest instance passed to it. 

But currently, these network services types are not applied to the input and output streams being used by SocketRocket. This pull request is adding that support.