### PR TITLE
Fix issue where we make the GET before checking the Server-side cert

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1415,6 +1415,12 @@ static const size_t SRFrameHeaderOverhead = 32;
                 });
                 return;
             }
+            
+            if (aStream == _outputStream && _pinnedCertFound) {
+                dispatch_async(_workQueue, ^{
+                    [self didConnect];
+                });
+            }
         }
     }
 
@@ -1427,7 +1433,7 @@ static const size_t SRFrameHeaderOverhead = 32;
                 }
                 assert(_readBuffer);
                 
-                if (self.readyState == SR_CONNECTING && aStream == _inputStream) {
+                if (!_secure && self.readyState == SR_CONNECTING && aStream == _inputStream) {
                     [self didConnect];
                 }
                 [self _pumpWriting];


### PR DESCRIPTION
Pentesting on our app shows that when we choose to pin to a certificate And the Web Socket Server requires an Authorization: header, then SocketRocket will make the GET (including the Authorization: header) before testing the Server Certificate.

This change moves the sending of the GET to a place in the NSStream work flow where we have the Server Cert to test against.