### PR TITLE
Remove semicolons before method bodies.

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -125,7 +125,7 @@ static NSString *newSHA1String(const char *bytes, size_t length) {
 
 @implementation NSData (SRWebSocket)
 
-- (NSString *)stringBySHA1ThenBase64Encoding;
+- (NSString *)stringBySHA1ThenBase64Encoding
 {
     return newSHA1String(self.bytes, self.length);
 }
@@ -135,7 +135,7 @@ static NSString *newSHA1String(const char *bytes, size_t length) {
 
 @implementation NSString (SRWebSocket)
 
-- (NSString *)stringBySHA1ThenBase64Encoding;
+- (NSString *)stringBySHA1ThenBase64Encoding
 {
     return newSHA1String(self.UTF8String, self.length);
 }
@@ -283,7 +283,7 @@ static __strong NSData *CRLFCRLF;
     CRLFCRLF = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
 }
 
-- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
+- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols
 {
     self = [super init];
     if (self) {
@@ -299,23 +299,23 @@ static __strong NSData *CRLFCRLF;
     return self;
 }
 
-- (id)initWithURLRequest:(NSURLRequest *)request;
+- (id)initWithURLRequest:(NSURLRequest *)request
 {
     return [self initWithURLRequest:request protocols:nil];
 }
 
-- (id)initWithURL:(NSURL *)url;
+- (id)initWithURL:(NSURL *)url
 {
     return [self initWithURL:url protocols:nil];
 }
 
-- (id)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
+- (id)initWithURL:(NSURL *)url protocols:(NSArray *)protocols
 {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];    
     return [self initWithURLRequest:request protocols:protocols];
 }
 
-- (void)_SR_commonInit;
+- (void)_SR_commonInit
 {
     
     NSString *scheme = _url.scheme.lowercaseString;
@@ -353,7 +353,7 @@ static __strong NSData *CRLFCRLF;
     // default handlers
 }
 
-- (void)assertOnWorkQueue;
+- (void)assertOnWorkQueue
 {
     assert(dispatch_get_specific((__bridge void *)self) == maybe_bridge(_workQueue));
 }
@@ -382,7 +382,7 @@ static __strong NSData *CRLFCRLF;
 
 #ifndef NDEBUG
 
-- (void)setReadyState:(SRReadyState)aReadyState;
+- (void)setReadyState:(SRReadyState)aReadyState
 {
     [self willChangeValueForKey:@"readyState"];
     assert(aReadyState > _readyState);
@@ -392,7 +392,7 @@ static __strong NSData *CRLFCRLF;
 
 #endif
 
-- (void)open;
+- (void)open
 {
     assert(_url);
     NSAssert(_readyState == SR_CONNECTING, @"Cannot call -(void)open on SRWebSocket more than once");
@@ -403,7 +403,7 @@ static __strong NSData *CRLFCRLF;
 }
 
 // Calls block on delegate queue
-- (void)_performDelegateBlock:(dispatch_block_t)block;
+- (void)_performDelegateBlock:(dispatch_block_t)block
 {
     if (_delegateOperationQueue) {
         [_delegateOperationQueue addOperationWithBlock:block];
@@ -413,7 +413,7 @@ static __strong NSData *CRLFCRLF;
     }
 }
 
-- (void)setDelegateDispatchQueue:(dispatch_queue_t)queue;
+- (void)setDelegateDispatchQueue:(dispatch_queue_t)queue
 {
     if (queue) {
         sr_dispatch_retain(queue);
@@ -426,7 +426,7 @@ static __strong NSData *CRLFCRLF;
     _delegateDispatchQueue = queue;
 }
 
-- (BOOL)_checkHandshake:(CFHTTPMessageRef)httpMessage;
+- (BOOL)_checkHandshake:(CFHTTPMessageRef)httpMessage
 {
     NSString *acceptHeader = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(httpMessage, CFSTR("Sec-WebSocket-Accept")));
 
@@ -440,7 +440,7 @@ static __strong NSData *CRLFCRLF;
     return [acceptHeader isEqualToString:expectedAccept];
 }
 
-- (void)_HTTPHeadersDidFinish;
+- (void)_HTTPHeadersDidFinish
 {
     NSInteger responseCode = CFHTTPMessageGetResponseStatusCode(_receivedHTTPHeaders);
     
@@ -480,7 +480,7 @@ static __strong NSData *CRLFCRLF;
 }
 
 
-- (void)_readHTTPHeader;
+- (void)_readHTTPHeader
 {
     if (_receivedHTTPHeaders == NULL) {
         _receivedHTTPHeaders = CFHTTPMessageCreateEmpty(NULL, NO);
@@ -543,7 +543,7 @@ static __strong NSData *CRLFCRLF;
     [self _readHTTPHeader];
 }
 
-- (void)_initializeStreams;
+- (void)_initializeStreams
 {
     assert(_url.port.unsignedIntValue <= UINT32_MAX);
     uint32_t port = _url.port.unsignedIntValue;
@@ -588,7 +588,7 @@ static __strong NSData *CRLFCRLF;
     _outputStream.delegate = self;
 }
 
-- (void)_connect;
+- (void)_connect
 {
     if (!_scheduledRunloops.count) {
         [self scheduleInRunLoop:[NSRunLoop SR_networkRunLoop] forMode:NSDefaultRunLoopMode];
@@ -599,7 +599,7 @@ static __strong NSData *CRLFCRLF;
     [_inputStream open];
 }
 
-- (void)scheduleInRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode;
+- (void)scheduleInRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode
 {
     [_outputStream scheduleInRunLoop:aRunLoop forMode:mode];
     [_inputStream scheduleInRunLoop:aRunLoop forMode:mode];
@@ -607,7 +607,7 @@ static __strong NSData *CRLFCRLF;
     [_scheduledRunloops addObject:@[aRunLoop, mode]];
 }
 
-- (void)unscheduleFromRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode;
+- (void)unscheduleFromRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode
 {
     [_outputStream removeFromRunLoop:aRunLoop forMode:mode];
     [_inputStream removeFromRunLoop:aRunLoop forMode:mode];
@@ -615,12 +615,12 @@ static __strong NSData *CRLFCRLF;
     [_scheduledRunloops removeObject:@[aRunLoop, mode]];
 }
 
-- (void)close;
+- (void)close
 {
     [self closeWithCode:SRStatusCodeNormal reason:nil];
 }
 
-- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
+- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason
 {
     assert(code);
     dispatch_async(_workQueue, ^{
@@ -666,7 +666,7 @@ static __strong NSData *CRLFCRLF;
     });
 }
 
-- (void)_closeWithProtocolError:(NSString *)message;
+- (void)_closeWithProtocolError:(NSString *)message
 {
     // Need to shunt this on the _callbackQueue first to see if they received any messages 
     [self _performDelegateBlock:^{
@@ -677,7 +677,7 @@ static __strong NSData *CRLFCRLF;
     }];
 }
 
-- (void)_failWithError:(NSError *)error;
+- (void)_failWithError:(NSError *)error
 {
     dispatch_async(_workQueue, ^{
         if (self.readyState != SR_CLOSED) {
@@ -698,7 +698,7 @@ static __strong NSData *CRLFCRLF;
     });
 }
 
-- (void)_writeData:(NSData *)data;
+- (void)_writeData:(NSData *)data
 {    
     [self assertOnWorkQueue];
 
@@ -709,7 +709,7 @@ static __strong NSData *CRLFCRLF;
     [self _pumpWriting];
 }
 
-- (void)send:(id)data;
+- (void)send:(id)data
 {
     NSAssert(self.readyState != SR_CONNECTING, @"Invalid State: Cannot call send: until connection is open");
     // TODO: maybe not copy this for performance
@@ -727,7 +727,7 @@ static __strong NSData *CRLFCRLF;
     });
 }
 
-- (void)sendPing:(NSData *)data;
+- (void)sendPing:(NSData *)data
 {
     NSAssert(self.readyState == SR_OPEN, @"Invalid State: Cannot call send: until connection is open");
     // TODO: maybe not copy this for performance
@@ -737,7 +737,7 @@ static __strong NSData *CRLFCRLF;
     });
 }
 
-- (void)handlePing:(NSData *)pingData;
+- (void)handlePing:(NSData *)pingData
 {
     // Need to pingpong this off _callbackQueue first to make sure messages happen in order
     [self _performDelegateBlock:^{
@@ -747,7 +747,7 @@ static __strong NSData *CRLFCRLF;
     }];
 }
 
-- (void)handlePong:(NSData *)pongData;
+- (void)handlePong:(NSData *)pongData
 {
     SRFastLog(@"Received pong");
     [self _performDelegateBlock:^{
@@ -800,7 +800,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
 //  encoded data with value /reason/, the interpretation of which is not
 //  defined by this specification.
 
-- (void)handleCloseWithData:(NSData *)data;
+- (void)handleCloseWithData:(NSData *)data
 {
     size_t dataSize = data.length;
     __block uint16_t closeCode = 0;
@@ -839,7 +839,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
     });
 }
 
-- (void)_disconnect;
+- (void)_disconnect
 {
     [self assertOnWorkQueue];
     SRFastLog(@"Trying to disconnect");
@@ -847,7 +847,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
     [self _pumpWriting];
 }
 
-- (void)_handleFrameWithData:(NSData *)frameData opCode:(NSInteger)opcode;
+- (void)_handleFrameWithData:(NSData *)frameData opCode:(NSInteger)opcode
 {                
     // Check that the current data is valid UTF8
     
@@ -893,7 +893,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
     }
 }
 
-- (void)_handleFrameHeader:(frame_header)frame_header curData:(NSData *)curData;
+- (void)_handleFrameHeader:(frame_header)frame_header curData:(NSData *)curData
 {
     assert(frame_header.opcode != 0);
     
@@ -977,7 +977,7 @@ static const uint8_t SRMaskMask         = 0x80;
 static const uint8_t SRPayloadLenMask   = 0x7F;
 
 
-- (void)_readFrameContinue;
+- (void)_readFrameContinue
 {
     assert((_currentFrameCount == 0 && _currentFrameOpcode == 0) || (_currentFrameCount > 0 && _currentFrameOpcode > 0));
 
@@ -1061,7 +1061,7 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
     } readToCurrentFrame:NO unmaskBytes:NO];
 }
 
-- (void)_readFrameNew;
+- (void)_readFrameNew
 {
     dispatch_async(_workQueue, ^{
         [_currentFrameData setLength:0];
@@ -1075,7 +1075,7 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
     });
 }
 
-- (void)_pumpWriting;
+- (void)_pumpWriting
 {
     [self assertOnWorkQueue];
     
@@ -1122,13 +1122,13 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
     }
 }
 
-- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback;
+- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback
 {
     [self assertOnWorkQueue];
     [self _addConsumerWithScanner:consumer callback:callback dataLength:0];
 }
 
-- (void)_addConsumerWithDataLength:(size_t)dataLength callback:(data_callback)callback readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+- (void)_addConsumerWithDataLength:(size_t)dataLength callback:(data_callback)callback readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes
 {   
     [self assertOnWorkQueue];
     assert(dataLength);
@@ -1137,7 +1137,7 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
     [self _pumpScanner];
 }
 
-- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback dataLength:(size_t)dataLength;
+- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback dataLength:(size_t)dataLength
 {    
     [self assertOnWorkQueue];
     [_consumers addObject:[_consumerPool consumerWithScanner:consumer handler:callback bytesNeeded:dataLength readToCurrentFrame:NO unmaskBytes:NO]];
@@ -1147,12 +1147,12 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
 
 static const char CRLFCRLFBytes[] = {'\r', '\n', '\r', '\n'};
 
-- (void)_readUntilHeaderCompleteWithCallback:(data_callback)dataHandler;
+- (void)_readUntilHeaderCompleteWithCallback:(data_callback)dataHandler
 {
     [self _readUntilBytes:CRLFCRLFBytes length:sizeof(CRLFCRLFBytes) callback:dataHandler];
 }
 
-- (void)_readUntilBytes:(const void *)bytes length:(size_t)length callback:(data_callback)dataHandler;
+- (void)_readUntilBytes:(const void *)bytes length:(size_t)length callback:(data_callback)dataHandler
 {
     // TODO optimize so this can continue from where we last searched
     stream_scanner consumer = ^size_t(NSData *data) {
@@ -1306,7 +1306,7 @@ static const char CRLFCRLFBytes[] = {'\r', '\n', '\r', '\n'};
 
 static const size_t SRFrameHeaderOverhead = 32;
 
-- (void)_sendFrameWithOpcode:(SROpCode)opcode data:(id)data;
+- (void)_sendFrameWithOpcode:(SROpCode)opcode data:(id)data
 {
     [self assertOnWorkQueue];
     
@@ -1384,7 +1384,7 @@ static const size_t SRFrameHeaderOverhead = 32;
     [self _writeData:frame];
 }
 
-- (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode;
+- (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode
 {
     if (_secure && !_pinnedCertFound && (eventCode == NSStreamEventHasBytesAvailable || eventCode == NSStreamEventHasSpaceAvailable)) {
         
@@ -1516,7 +1516,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 @synthesize readToCurrentFrame = _readToCurrentFrame;
 @synthesize unmaskBytes = _unmaskBytes;
 
-- (void)setupWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+- (void)setupWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes
 {
     _scanner = [scanner copy];
     _handler = [handler copy];
@@ -1535,7 +1535,7 @@ static const size_t SRFrameHeaderOverhead = 32;
     NSMutableArray *_bufferedConsumers;
 }
 
-- (id)initWithBufferCapacity:(NSUInteger)poolSize;
+- (id)initWithBufferCapacity:(NSUInteger)poolSize
 {
     self = [super init];
     if (self) {
@@ -1550,7 +1550,7 @@ static const size_t SRFrameHeaderOverhead = 32;
     return [self initWithBufferCapacity:8];
 }
 
-- (SRIOConsumer *)consumerWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+- (SRIOConsumer *)consumerWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes
 {
     SRIOConsumer *consumer = nil;
     if (_bufferedConsumers.count) {
@@ -1565,7 +1565,7 @@ static const size_t SRFrameHeaderOverhead = 32;
     return consumer;
 }
 
-- (void)returnConsumer:(SRIOConsumer *)consumer;
+- (void)returnConsumer:(SRIOConsumer *)consumer
 {
     if (_bufferedConsumers.count < _poolSize) {
         [_bufferedConsumers addObject:consumer];
@@ -1577,7 +1577,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 @implementation  NSURLRequest (CertificateAdditions)
 
-- (NSArray *)SR_SSLPinnedCertificates;
+- (NSArray *)SR_SSLPinnedCertificates
 {
     return [NSURLProtocol propertyForKey:@"SR_SSLPinnedCertificates" inRequest:self];
 }
@@ -1586,12 +1586,12 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 @implementation  NSMutableURLRequest (CertificateAdditions)
 
-- (NSArray *)SR_SSLPinnedCertificates;
+- (NSArray *)SR_SSLPinnedCertificates
 {
     return [NSURLProtocol propertyForKey:@"SR_SSLPinnedCertificates" inRequest:self];
 }
 
-- (void)setSR_SSLPinnedCertificates:(NSArray *)SR_SSLPinnedCertificates;
+- (void)setSR_SSLPinnedCertificates:(NSArray *)SR_SSLPinnedCertificates
 {
     [NSURLProtocol setProperty:SR_SSLPinnedCertificates forKey:@"SR_SSLPinnedCertificates" inRequest:self];
 }
@@ -1600,7 +1600,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 @implementation NSURL (SRWebSocket)
 
-- (NSString *)SR_origin;
+- (NSString *)SR_origin
 {
     NSString *scheme = [self.scheme lowercaseString];
         
@@ -1743,7 +1743,7 @@ static NSRunLoop *networkRunLoop = nil;
     return self;
 }
 
-- (void)main;
+- (void)main
 {
     @autoreleasepool {
         _runLoop = [NSRunLoop currentRunLoop];
@@ -1759,7 +1759,7 @@ static NSRunLoop *networkRunLoop = nil;
     }
 }
 
-- (NSRunLoop *)runLoop;
+- (NSRunLoop *)runLoop
 {
     dispatch_group_wait(_waitGroup, DISPATCH_TIME_FOREVER);
     return _runLoop;


### PR DESCRIPTION
Fixes XCode 6.3 beta 2 warnings.

Fixes issue #232 