### PR TITLE
Update podspec

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name               = "SocketRocket"
-  s.version            = '0.3.1-beta2'
+  s.version            = '0.3.2'
   s.summary            = 'A conforming WebSocket (RFC 6455) client library.'
   s.homepage           = 'https://github.com/square/SocketRocket'
   s.authors            = 'Square'
   s.license            = 'Apache License, Version 2.0'
-  s.source             = { :git => 'https://github.com/square/SocketRocket.git', :commit => '82c9f8938f8b9b7aa578866cb7ce56bc11e52ced' }
+  s.source             = { :git => 'https://github.com/square/SocketRocket.git', :commit => 'd1e796c05a8b6dfa662a7cf3cfdce17d0d88c618' }
   s.source_files       = 'SocketRocket/*.{h,m,c}'
   s.requires_arc       = true
   s.ios.frameworks     = %w{CFNetwork Security}


### PR DESCRIPTION
Would be great to make versions newer than two years old accessible via CocoaPods. I'm happy to use different version number if you prefer, or reference a commit directly, but I think it make sense to tag and push this version. Let me know!