### PR TITLE
Fix 64 bit build error

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1693,7 +1693,7 @@ static inline int32_t validate_dispatch_data_partial_string(NSData *data) {
     for (int i = 0; i < maxCodepointSize; i++) {
         NSString *str = [[NSString alloc] initWithBytesNoCopy:(char *)data.bytes length:data.length - i encoding:NSUTF8StringEncoding freeWhenDone:NO];
         if (str) {
-            return data.length - i;
+            return (int32_t)data.length - i;
         }
     }
     


### PR DESCRIPTION
SRWebSocket.m:1696:32: error: implicit conversion loses integer precision: 'unsigned long' to 'int32_t' (aka 'int') [-Werror,-Wshorten-64-to-32]
            return data.length - i;
            ~~~~~~ ~~~~~~~~~~~~^~~