### PR TITLE
Added ability to provide cookies for the web socket connection

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -57,6 +57,9 @@ extern NSString *const SRHTTPResponseErrorKey;
 
 @property (nonatomic, readonly) CFHTTPMessageRef receivedHTTPHeaders;
 
+// Optional array of cookies (NSHTTPCookie objects) to apply to the connections
+@property (nonatomic, readwrite) NSArray * requestCookies;
+
 // This returns the negotiated protocol.
 // It will be nil until after the handshake completes.
 @property (nonatomic, readonly, copy) NSString *protocol;

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -494,7 +494,16 @@ static __strong NSData *CRLFCRLF;
     }
     
     assert([_secKey length] == 24);
-    
+
+    // Apply cookies if any have been provided
+    NSDictionary * cookies = [NSHTTPCookie requestHeaderFieldsWithCookies:[self requestCookies]];
+    for (NSString * cookieKey in cookies) {
+        NSString * cookieValue = [cookies objectForKey:cookieKey];
+        if ([cookieKey length] && [cookieValue length]) {
+            CFHTTPMessageSetHeaderFieldValue(request, (__bridge CFStringRef)cookieKey, (__bridge CFStringRef)cookieValue);
+        }
+    }
+ 
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Upgrade"), CFSTR("websocket"));
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Connection"), CFSTR("Upgrade"));
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Sec-WebSocket-Key"), (__bridge CFStringRef)_secKey);


### PR DESCRIPTION
For web sockets used behind an already authenticated HTTP(S) session you might want to provide the session cookie or other cookies appropriate for the web socket connection (for example Spring's SessionID when connecting to a Spring-authentication java backend server).

Sample usage for the clients could be:

```
[[self webSocket] setRequestCookies:[[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies]];
```

Note that you might want to limit the cookies provided to the WebSocket based on the URL (cookiesForURL:).

This is a refreshed PR from https://github.com/square/SocketRocket/pull/133
