### PR TITLE
Make chatroom.go pass golint and gofmt

### DIFF
--- a/TestChatServer/go/chatroom.go
+++ b/TestChatServer/go/chatroom.go
@@ -1,60 +1,61 @@
 package main
 
 import (
-    "code.google.com/p/go.net/websocket"
-    "net/http"
+	"code.google.com/p/go.net/websocket"
+	"net/http"
 )
 
+// Msg stores both the message and the connection
 type Msg struct {
-    sender *websocket.Conn
-    msg    string
+	sender *websocket.Conn
+	msg    string
 }
 
 func run(reg chan *websocket.Conn, unreg chan *websocket.Conn, msg chan Msg) {
-    conns := make(map[*websocket.Conn]int)
-    for {
-        select {
-        case c := <-reg:
-            conns[c] = 1
-        case c := <-unreg:
-            delete(conns, c)
-        case msg := <-msg:
-            for c := range conns {
-                if c != msg.sender {
-                    websocket.Message.Send(c, msg.msg)
-                }
-            }
-        }
-    }
+	conns := make(map[*websocket.Conn]int)
+	for {
+		select {
+		case c := <-reg:
+			conns[c] = 1
+		case c := <-unreg:
+			delete(conns, c)
+		case msg := <-msg:
+			for c := range conns {
+				if c != msg.sender {
+					websocket.Message.Send(c, msg.msg)
+				}
+			}
+		}
+	}
 }
 
 func newChatServer(reg chan *websocket.Conn, unreg chan *websocket.Conn, msg chan Msg) websocket.Handler {
-    return func(ws *websocket.Conn) {
-        reg <- ws
-        for {
-            var message string
-            err := websocket.Message.Receive(ws, &message)
-            if err != nil {
-                unreg <- ws
-                break
-            }
-            msg <- Msg{ws, message}
-        }
-    }
+	return func(ws *websocket.Conn) {
+		reg <- ws
+		for {
+			var message string
+			err := websocket.Message.Receive(ws, &message)
+			if err != nil {
+				unreg <- ws
+				break
+			}
+			msg <- Msg{ws, message}
+		}
+	}
 }
 
 func main() {
-    reg := make(chan *websocket.Conn)
-    unreg := make(chan *websocket.Conn)
-    msg := make(chan Msg)
+	reg := make(chan *websocket.Conn)
+	unreg := make(chan *websocket.Conn)
+	msg := make(chan Msg)
 
-    http.Handle("/chat", websocket.Handler(newChatServer(reg, unreg, msg)))
-    http.Handle("/", http.FileServer(http.Dir("../static")))
+	http.Handle("/chat", websocket.Handler(newChatServer(reg, unreg, msg)))
+	http.Handle("/", http.FileServer(http.Dir("../static")))
 
-    go run(reg, unreg, msg)
+	go run(reg, unreg, msg)
 
-    err := http.ListenAndServe(":9000", nil)
-    if err != nil {
-        panic("ListenAndServe: " + err.Error())
-    }
+	err := http.ListenAndServe(":9000", nil)
+	if err != nil {
+		panic("ListenAndServe: " + err.Error())
+	}
 }


### PR DESCRIPTION
This commit makes `TestChatServer/go/chatroom.go` pass `golint` and conform to the `gofmt` standard formatting.  There are no functional changes—it adds a single comment (required by the linter) and otherwise only changes formatting.

Incidentally, this is my first time contributing to an open source project, so do let me know if I've screwed anything up or committed a faux pas.