### PR TITLE
Add tvos as deployment target

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
+  s.tvos.deployment_target = '9.0'
 
   s.ios.frameworks     = 'CFNetwork', 'Security'
   s.osx.frameworks     = 'CoreServices', 'Security'


### PR DESCRIPTION
As the title says, add support for tvOS as a deployment target. 

I've tested it here: https://github.com/hamchapman/libPusherTVOSTest with an app that uses libPusher (https://github.com/lukeredpath/libPusher) which in turn makes use SocketRocket and everything seemed to be working fine.

Still waiting for Cocoapods to merge in the tvOS stuff as well (https://github.com/CocoaPods/Core/pull/263)