### PR TITLE
Prevent SocketRocket killing the connection before notifying of final messages

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1435,20 +1435,22 @@ static const size_t SRFrameHeaderOverhead = 32;
                 if (aStream.streamError) {
                     [self _failWithError:aStream.streamError];
                 } else {
-                    if (self.readyState != SR_CLOSED) {
-                        self.readyState = SR_CLOSED;
-                        _selfRetain = nil;
-                    }
+                    dispatch_async(_workQueue, ^{
+                        if (self.readyState != SR_CLOSED) {
+                            self.readyState = SR_CLOSED;
+                            _selfRetain = nil;
+                        }
 
-                    if (!_sentClose && !_failed) {
-                        _sentClose = YES;
-                        // If we get closed in this state it's probably not clean because we should be sending this when we send messages
-                        [self _performDelegateBlock:^{
-                            if ([self.delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)]) {
-                                [self.delegate webSocket:self didCloseWithCode:SRStatusCodeGoingAway reason:@"Stream end encountered" wasClean:NO];
-                            }
-                        }];
-                    }
+                        if (!_sentClose && !_failed) {
+                            _sentClose = YES;
+                            // If we get closed in this state it's probably not clean because we should be sending this when we send messages
+                            [self _performDelegateBlock:^{
+                                if ([self.delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)]) {
+                                    [self.delegate webSocket:self didCloseWithCode:SRStatusCodeGoingAway reason:@"Stream end encountered" wasClean:NO];
+                                }
+                            }];
+                        }
+                    });
                 }
                 
                 break;


### PR DESCRIPTION
We are noticing a race condition when connecting to Firebase from our React Native project, which itself uses a fork of SocketRocket.  I believe the code is the same in the place in question, so I wanted to see if we could get this verified/fixed in SocketRocket, and then get React Native to pick up the change if valid.

The issue appears to be a race between hitting NSStreamEventEndEncountered and receiving any final messages the server may have sent before closing the connection.

My patch just changes closing/cleanup from running immediately, to instead happen on the next dispatch_async _workQueue.  I haven't been able to reproduce the issue since making this change.  _failWithError itself already shells out to dispatch_async _workQueue, so this patch would seem consistent with that behavior.  But we really need someone who knows the internals/implications of this to take a look.