### PR TITLE
issue #299: Handle server frames also when ReadyState is SR_Closing 

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name               = "SocketRocket"
-  s.version            = '0.4.1'
+  s.version            = '0.4.2'
   s.summary            = 'A conforming WebSocket (RFC 6455) client library.'
   s.homepage           = 'https://github.com/square/SocketRocket'
   s.authors            = 'Square'

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1649,7 +1649,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 @end
 
-#define SR_ENABLE_LOG
+//#define SR_ENABLE_LOG
 
 static inline void SRFastLog(NSString *format, ...)  {
 #ifdef SR_ENABLE_LOG

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -921,7 +921,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
 {
     assert(frame_header.opcode != 0);
     
-    if (self.readyState != SR_OPEN) {
+    if (self.readyState == SR_CLOSED) {
         return;
     }
     

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1207,7 +1207,7 @@ static const char CRLFCRLFBytes[] = {'\r', '\n', '\r', '\n'};
     
     BOOL didWork = NO;
     
-    if (self.readyState >= SR_CLOSING) {
+    if (self.readyState >= SR_CLOSED) {
         return didWork;
     }
     

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1649,7 +1649,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 @end
 
-//#define SR_ENABLE_LOG
+#define SR_ENABLE_LOG
 
 static inline void SRFastLog(NSString *format, ...)  {
 #ifdef SR_ENABLE_LOG


### PR DESCRIPTION
Instead of returning the handlers if ReadyState is SR_Closing returns only on ReadyState SR_Closed

Now the close handshake succeeds.