### PR TITLE
Fixed connecting limbo

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1478,9 +1478,7 @@ static const size_t SRFrameHeaderOverhead = 32;
                     [self _failWithError:[NSError errorWithDomain:SRWebSocketErrorDomain code:23556 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Invalid server cert"] forKey:NSLocalizedDescriptionKey]]];
                 });
                 return;
-            }
-            
-            if (aStream == _outputStream && _pinnedCertFound) {
+            } else if (aStream == _outputStream) {
                 dispatch_async(_workQueue, ^{
                     [self didConnect];
                 });
@@ -1497,7 +1495,9 @@ static const size_t SRFrameHeaderOverhead = 32;
                 }
                 assert(_readBuffer);
                 
-                if (!_secure && self.readyState == SR_CONNECTING && aStream == _inputStream) {
+                // didConnect fires after certificate verification if we're using pinned certificates.
+                BOOL usingPinnedCerts = [[_urlRequest SR_SSLPinnedCertificates] count] > 0;
+                if ((!_secure || !usingPinnedCerts) && self.readyState == SR_CONNECTING && aStream == _inputStream) {
                     [self didConnect];
                 }
                 [self _pumpWriting];


### PR DESCRIPTION
This fixes an issue where a socket would be stuck in "connecting" state if using SSL without a pinned certificate.

Resolves https://github.com/square/SocketRocket/issues/308