### PR TITLE
- Fix OS X build by checking if OS is iOS 9 only on iOS target OSs.

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -623,7 +623,7 @@ static __strong NSData *CRLFCRLF;
             break;
         case NSURLNetworkServiceTypeVoIP: {
             networkServiceType = NSStreamNetworkServiceTypeVoIP;
-#ifdef __IPHONE_9_0
+#if TARGET_OS_IPHONE && __IPHONE_9_0
             if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_3) {
                 static dispatch_once_t predicate;
                 dispatch_once(&predicate, ^{


### PR DESCRIPTION
OS X framework build is broken, this patch fixes it by checking if the current OS is iOS 9 only when building for iOS 