### PR TITLE
Respect timeouts set on `NSURLRequest`s passed at init fix #70

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -389,7 +389,16 @@ static __strong NSData *CRLFCRLF;
     NSAssert(_readyState == SR_CONNECTING, @"Cannot call -(void)open on SRWebSocket more than once");
 
     _selfRetain = self;
-    
+
+    if (_urlRequest.timeoutInterval > 0)
+    {
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, _urlRequest.timeoutInterval * NSEC_PER_SEC);
+        dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+            if (self.readyState == SR_CONNECTING)
+                [self _failWithError:[NSError errorWithDomain:@"com.squareup.SocketRocket" code:60 userInfo:@{NSLocalizedDescriptionKey: @"Timeout Connecting to Server"}]];
+        });
+    }
+
     [self openConnection];
 }
 

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -395,7 +395,7 @@ static __strong NSData *CRLFCRLF;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, _urlRequest.timeoutInterval * NSEC_PER_SEC);
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
             if (self.readyState == SR_CONNECTING)
-                [self _failWithError:[NSError errorWithDomain:@"com.squareup.SocketRocket" code:60 userInfo:@{NSLocalizedDescriptionKey: @"Timeout Connecting to Server"}]];
+                [self _failWithError:[NSError errorWithDomain:@"com.squareup.SocketRocket" code:504 userInfo:@{NSLocalizedDescriptionKey: @"Timeout Connecting to Server"}]];
         });
     }
 


### PR DESCRIPTION
Per https://github.com/square/SocketRocket/issues/70 & https://github.com/square/SocketRocket/issues/264. Code lovingly lifted from https://github.com/jonathanxie/SocketRocket/commit/3bf8e340baba1c06cb693e7ca2c74c504417db73 (thanks @jonathanxie).

Noticed several PRs with a similar fix have been rejected before. They all did more than just add timeouts though, so hoping this atomic commit will land.

Tests continue to pass, though none were added for this change.