### PR TITLE
Updates throughout test-related files to try and make run_test.sh work

### DIFF
--- a/TestSupport/ensure_virtualenv.sh
+++ b/TestSupport/ensure_virtualenv.sh
@@ -6,6 +6,7 @@ else
 	python extern/virtualenv/virtualenv.py $VIRTUALENV_PATH
 	source $VIRTUALENV_PATH/bin/activate
 	pushd TestSupport/sr-testharness/
+  env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install cryptography
 	python setup.py develop
 	popd
 fi

--- a/TestSupport/run_test.sh
+++ b/TestSupport/run_test.sh
@@ -11,16 +11,16 @@ pushd TestSupport/sr-testharness/
 python setup.py develop
 popd
 
-source .env/bin/activate 
+source .env/bin/activate
 sr-testharness -i '' -c "$TEST_SCENARIOS" &
 
 CHILD_PID=$!
 
-extra_opts="VALID_ARCHS=i386 ARCH=i386"
+DESTINATION="OS=9.2,name=iPhone 6s"
+SDK="iphonesimulator"
+SHARED_ARGS="-configuration $CONFIGURATION -sdk $SDK"
 
-SHARED_ARGS="-arch i386 -configuration $CONFIGURATION -sdk iphonesimulator"
-
-xcodebuild -scheme SocketRocketTests $SHARED_ARGS TEST_AFTER_BUILD=YES  clean build $extra_opts
+xcodebuild -scheme SocketRocketTests -destination "$DESTINATION" $SHARED_ARGS TEST_AFTER_BUILD=YES clean build
 RESULT=$?
 
 kill $CHILD_PID

--- a/TestSupport/sr-testharness/setup.py
+++ b/TestSupport/sr-testharness/setup.py
@@ -20,7 +20,8 @@ setup(name='srtestharness',
       install_requires=[
           # -*- Extra requirements: -*-
           'autobahntestsuite',
-          'autobahn',
+          'autobahn==0.10.1',
+          'cryptography>=0.7'
       ],
       entry_points="""
       # -*- Entry points: -*-

--- a/TestSupport/sr-testharness/srtestharness/runner.py
+++ b/TestSupport/sr-testharness/srtestharness/runner.py
@@ -9,7 +9,7 @@ from twisted.internet import reactor
 from twisted.web.server import Site
 from twisted.web.static import File
 from autobahntestsuite.fuzzing import FuzzingServerFactory
-from autobahn.websocket import listenWS
+from autobahn.twisted.websocket import listenWS
 
 class jsondict(dict):
     def __init__(self, json_value):


### PR DESCRIPTION
I have openssl installed via homebrew and had to explicitly install `cryptography` using pip, otherwise it would always fail when running `make test`.

I also had to explicitly set the `DESTINATION` variable in the `xcodebuild` command as specifying architectures doesn't currently work as expected with Xcode 7.2.

Then I also had to change an import in `runner.py`.

Also made some dependency versions explicit as only certain versions seem to play nicely.