### PR TITLE
Always return NSData in didReceiveMessage: delegate method

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -124,6 +124,9 @@ extern NSString *const SRHTTPResponseErrorKey;
 - (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
 - (void)webSocket:(SRWebSocket *)webSocket didReceivePong:(NSData *)pongPayload;
 
+// Return YES to convert messages sent as Text to an NSString. Return NO to skip NSData -> NSString conversion for Text messages. Defaults to YES.
+- (BOOL)webSocketShouldConvertTextFrameToString:(SRWebSocket *)webSocket;
+
 @end
 
 #pragma mark - NSURLRequest (SRCertificateAdditions)


### PR DESCRIPTION
This is an optimization for a common use case where the server is sending text serialized as JSON. Having socket rocket convert the NSData to an NSString is undesirable because the delegate will be immediately converting back into NSData before passing that to NSJSONSerialization. With this pull request, the client would avoid two data <--> string conversions.